### PR TITLE
[VBLOCKS-1494] feat: outgoing ux improvements

### DIFF
--- a/app/src/screens/Call/index.tsx
+++ b/app/src/screens/Call/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Dialpad from '../../components/Dialpad';
 import RemoteParticipant from './RemoteParticipant';
@@ -8,6 +8,9 @@ import SelectAudioOutputDeviceButton from './SelectAudioOutputDeviceButton';
 import ShowDialpadButton from './ShowDialpadButton';
 import HideDialpadButton from './HideDialpadButton';
 import useCall from './hooks';
+import { useNavigation } from '@react-navigation/native';
+import { type StackNavigationProp } from '../../types';
+import { Call as TwilioCall } from '@twilio/voice-react-native-sdk';
 
 const Call: React.FC = () => {
   const {
@@ -54,6 +57,14 @@ const Call: React.FC = () => {
     ),
     [dialpad, hangup, mute, selectAudioOutputDevice],
   );
+
+  const navigation = useNavigation<StackNavigationProp<'App'>>();
+
+  useEffect(() => {
+    if (callStatus === TwilioCall.State.Disconnected) {
+      setTimeout(() => navigation.navigate('Dialer'), 1000);
+    }
+  }, [callStatus, navigation]);
 
   return (
     <View style={styles.container}>

--- a/app/src/screens/Dialer/ToggleClientInputButton.tsx
+++ b/app/src/screens/Dialer/ToggleClientInputButton.tsx
@@ -17,7 +17,7 @@ const ToggleClientInputButton: React.FC<Props> = ({
   <Button disabled={disabled} size={96} onPress={onPress}>
     <Image source={TypeSource} resizeMode="contain" style={styles.image} />
     <Text style={styles.text}>
-      {recipientType === 'number' ? 'Number' : 'Client'}
+      {recipientType === 'number' ? 'Client' : 'Number'}
     </Text>
   </Button>
 );

--- a/app/src/screens/Dialer/index.tsx
+++ b/app/src/screens/Dialer/index.tsx
@@ -16,6 +16,11 @@ const Dialer: React.FC = () => {
     recipient,
   } = useDialer();
 
+  const isOutgoingCallButtonDisabled =
+    dialpad.outgoingNumber === '' || isDisabled;
+
+  const isBackSpaceVisible = dialpad.outgoingNumber !== '';
+
   return (
     <View style={styles.container}>
       <View style={styles.spacer} />
@@ -38,13 +43,17 @@ const Dialer: React.FC = () => {
           recipientType={recipient.type}
         />
         <MakeOutgoingCallButton
-          disabled={isDisabled}
+          disabled={isOutgoingCallButtonDisabled}
           onPress={makeOutgoingCall.handle}
         />
-        <BackspaceButton
-          disabled={isDisabled}
-          onPress={dialpad.handleBackspace}
-        />
+        {isBackSpaceVisible ? (
+          <BackspaceButton
+            disabled={isDisabled}
+            onPress={dialpad.handleBackspace}
+          />
+        ) : (
+          <View style={styles.emptyButton} />
+        )}
       </View>
       <View style={styles.spacer} />
     </View>
@@ -68,6 +77,9 @@ const styles = StyleSheet.create({
   buttons: {
     display: 'flex',
     flexDirection: 'row',
+  },
+  emptyButton: {
+    width: 96,
   },
 });
 


### PR DESCRIPTION
[VBLOCKS-1494](https://issues.corp.twilio.com/browse/VBLOCKS-1494)

- don't allow calling empty numbers
- remove back space when no number
- Fix text on toggle to read 'Client' when using number
- auto navigate back to dialer after call has ended (1 second timeout)

Figma Ref: https://www.figma.com/file/IFiFQzWEp1xyM2nuqJCkC2/2022-Q2-React-Voice-SDK?node-id=629-19201&t=uIDqNjfDOVKLVVt8-0

## Before:

![dialer](https://user-images.githubusercontent.com/22135968/223575482-53f733b4-c828-4dd1-b100-7cc945a52c9f.jpg)

## After:

Android & iOS

<img width="965" alt="Screen Shot 2023-03-30 at 3 46 26 PM" src="https://user-images.githubusercontent.com/35968892/228982441-416e0305-4537-45fb-a80b-c4e261347d1d.png">


<img width="963" alt="Screen Shot 2023-03-30 at 3 58 49 PM" src="https://user-images.githubusercontent.com/35968892/228983189-ef016a7b-2340-4905-ab42-577c34e4a296.png">


https://user-images.githubusercontent.com/35968892/228982476-555cbb62-8d2e-47ce-8f82-cd997e0553c0.mov




**Contributing to Twilio**


> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
