### PR TITLE
[VBLOCKS-1580] fix: detox with auth0

### DIFF
--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -56,9 +56,9 @@ allprojects {
     }
 }
 
-// fix detox with auth0 error, reference: https://github.com/auth0/react-native-auth0/issues/387#issuecomment-918483390 
 subprojects {
     afterEvaluate { subproject ->
+        // fix detox with auth0 error, reference: https://github.com/auth0/react-native-auth0/issues/387#issuecomment-918483390 
         if (subproject.name == 'react-native-auth0') {
             def String taskRequests = getGradle().getStartParameter().getTaskRequests().toString()
             if (taskRequests.contains("assembleAndroidTest")) {

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -55,3 +55,19 @@ allprojects {
         maven { url 'https://www.jitpack.io' }
     }
 }
+
+// fix detox with auth0 error, reference: https://github.com/auth0/react-native-auth0/issues/387#issuecomment-918483390 
+subprojects {
+    afterEvaluate { subproject ->
+        if (subproject.name == 'react-native-auth0') {
+            def String taskRequests = getGradle().getStartParameter().getTaskRequests().toString()
+            if (taskRequests.contains("assembleAndroidTest")) {
+                android {
+                    defaultConfig {
+                        manifestPlaceholders = [auth0Domain: "E2E_TEST", auth0Scheme: "com.E2E.TEST"]
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
[VBLOCKS-1580](https://issues.corp.twilio.com/browse/VBLOCKS-1580)

Update build.gradle with subproject auth0 

Reference: https://github.com/auth0/react-native-auth0/issues/387#issuecomment-918483390

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
