### PR TITLE
[VBLOCKS-1834] Refactor auth util

### DIFF
--- a/app/src/screens/Home/index.tsx
+++ b/app/src/screens/Home/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { type Dispatch, type State } from '../../store/app';
-import { logout } from '../../util/auth';
+import { logout } from '../../store/user';
 
 const TwilioLogo = require('../../../assets/icons/twilio-logo.png');
 

--- a/app/src/store/__tests__/bootstrap.test.ts
+++ b/app/src/store/__tests__/bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { type Middleware } from '@reduxjs/toolkit';
 import { createStore, Store } from '../app';
 import { bootstrapUser, bootstrapCallInvites } from '../bootstrap';
-import { checkLoginStatus } from '../../util/auth';
+import { checkLoginStatus } from '../user';
 import { getAccessToken } from '../voice/accessToken';
 import { setCallInvite } from '../voice/call/callInvite';
 import { register } from '../voice/registration';
@@ -53,6 +53,7 @@ describe('bootstrap', () => {
       expect(payload).toStrictEqual('LOGGED_IN');
 
       expect(store.getState().user).toStrictEqual({
+        action: 'checkLoginStatus',
         accessToken: 'test token',
         email: 'test email',
         status: 'fulfilled',

--- a/app/src/store/__tests__/registration.test.ts
+++ b/app/src/store/__tests__/registration.test.ts
@@ -1,6 +1,6 @@
-import { Middleware } from '@reduxjs/toolkit';
+import { type Middleware } from '@reduxjs/toolkit';
 import { createStore, Store } from '../app';
-import * as authStoreModule from '../../util/auth';
+import * as user from '../user';
 import * as accessTokenStoreModule from '../voice/accessToken';
 import * as registrationStoreModule from '../voice/registration';
 import * as auth0 from '../../../__mocks__/react-native-auth0';
@@ -57,8 +57,8 @@ describe('registration', () => {
 
       matchDispatchedActions(dispatchedActions, [
         registrationStoreModule.loginAndRegister.pending,
-        authStoreModule.login.pending,
-        authStoreModule.login.fulfilled,
+        user.login.pending,
+        user.login.fulfilled,
         accessTokenStoreModule.getAccessToken.pending,
         accessTokenStoreModule.getAccessToken.fulfilled,
         registrationStoreModule.register.pending,
@@ -83,8 +83,8 @@ describe('registration', () => {
 
         matchDispatchedActions(dispatchedActions, [
           registrationStoreModule.loginAndRegister.pending,
-          authStoreModule.login.pending,
-          authStoreModule.login.rejected,
+          user.login.pending,
+          user.login.rejected,
           registrationStoreModule.loginAndRegister.rejected,
         ]);
       });
@@ -104,8 +104,8 @@ describe('registration', () => {
 
         matchDispatchedActions(dispatchedActions, [
           registrationStoreModule.loginAndRegister.pending,
-          authStoreModule.login.pending,
-          authStoreModule.login.fulfilled,
+          user.login.pending,
+          user.login.fulfilled,
           accessTokenStoreModule.getAccessToken.pending,
           accessTokenStoreModule.getAccessToken.rejected,
           registrationStoreModule.loginAndRegister.rejected,
@@ -127,8 +127,8 @@ describe('registration', () => {
 
         matchDispatchedActions(dispatchedActions, [
           registrationStoreModule.loginAndRegister.pending,
-          authStoreModule.login.pending,
-          authStoreModule.login.fulfilled,
+          user.login.pending,
+          user.login.fulfilled,
           accessTokenStoreModule.getAccessToken.pending,
           accessTokenStoreModule.getAccessToken.fulfilled,
           registrationStoreModule.register.pending,

--- a/app/src/store/__tests__/store.test.ts
+++ b/app/src/store/__tests__/store.test.ts
@@ -1,7 +1,7 @@
 import * as app from '../app';
 import * as token from '../voice/accessToken';
 import * as outgoingCall from '../voice/call/outgoingCall';
-import * as auth from '../../util/auth';
+import * as user from '../user';
 
 let fetchMock: jest.Mock;
 let voiceConnectMock: jest.Mock;
@@ -45,7 +45,7 @@ it('should export a default store', () => {
 it('should make an outgoing call and mute it', async () => {
   const store: app.Store = app.createStore();
 
-  await store.dispatch(auth.checkLoginStatus());
+  await store.dispatch(user.checkLoginStatus());
 
   fetchMock.mockResolvedValueOnce({
     ok: true,

--- a/app/src/store/__tests__/token.test.ts
+++ b/app/src/store/__tests__/token.test.ts
@@ -1,6 +1,6 @@
 import { miniSerializeError } from '@reduxjs/toolkit';
 import * as token from '../voice/accessToken';
-import * as auth from '../../util/auth';
+import * as user from '../user';
 import * as app from '../app';
 import * as auth0 from '../../../__mocks__/react-native-auth0';
 
@@ -45,7 +45,7 @@ describe('token store', () => {
       ok: true,
       text: jest.fn().mockResolvedValueOnce('foo'),
     });
-    await store.dispatch(auth.login());
+    await store.dispatch(user.login());
     await store.dispatch(token.getAccessToken());
     expect(fetchMock).toBeCalledTimes(1);
     expect(store.getState().voice.accessToken).toEqual({
@@ -56,7 +56,7 @@ describe('token store', () => {
 
   it('rejects if no user', async () => {
     jest.spyOn(auth0, 'authorize').mockResolvedValueOnce({ undefined });
-    await store.dispatch(auth.login());
+    await store.dispatch(user.login());
     await store.dispatch(token.getAccessToken());
     expect(store.getState().voice.accessToken).toEqual({
       status: 'rejected',
@@ -71,7 +71,7 @@ describe('token store', () => {
     });
     const error = new Error('error');
     fetchMock.mockRejectedValueOnce(error);
-    await store.dispatch(auth.login());
+    await store.dispatch(user.login());
     await store.dispatch(token.getAccessToken());
     expect(store.getState().voice.accessToken).toEqual({
       status: 'rejected',
@@ -88,7 +88,7 @@ describe('token store', () => {
     fetchMock.mockResolvedValueOnce({
       ok: false,
     });
-    await store.dispatch(auth.login());
+    await store.dispatch(user.login());
     await store.dispatch(token.getAccessToken());
     expect(store.getState().voice.accessToken).toEqual({
       reason: 'TOKEN_RESPONSE_NOT_OK',
@@ -106,7 +106,7 @@ describe('token store', () => {
       ok: true,
       text: jest.fn().mockRejectedValueOnce(error),
     });
-    await store.dispatch(auth.login());
+    await store.dispatch(user.login());
     await store.dispatch(token.getAccessToken());
     expect(store.getState().voice.accessToken).toEqual({
       status: 'rejected',

--- a/app/src/store/__tests__/user.test.ts
+++ b/app/src/store/__tests__/user.test.ts
@@ -1,6 +1,7 @@
-import * as app from '../app';
+import { miniSerializeError } from '@reduxjs/toolkit';
 import * as auth0 from '../../../__mocks__/react-native-auth0';
-import * as auth from '../../util/auth';
+import * as app from '../app';
+import * as user from '../user';
 
 let MockCall: { Event: Record<string, string> };
 
@@ -43,9 +44,10 @@ describe('user store', () => {
   });
 
   it('should login a user', async () => {
-    await store.dispatch(auth.login());
+    await store.dispatch(user.login());
     const userState = store.getState().user;
     expect(userState).toEqual({
+      action: 'login',
       status: 'fulfilled',
       accessToken: 'test token',
       email: 'test email',
@@ -53,10 +55,11 @@ describe('user store', () => {
   });
 
   it('should logout a user', async () => {
-    await store.dispatch(auth.login());
-    await store.dispatch(auth.logout());
+    await store.dispatch(user.login());
+    await store.dispatch(user.logout());
     const userState = store.getState().user;
     expect(userState).toEqual({
+      action: 'logout',
       status: 'fulfilled',
       accessToken: '',
       email: '',
@@ -64,21 +67,25 @@ describe('user store', () => {
   });
 
   it('should check if a user is NOT logged in', async () => {
-    jest.spyOn(auth0, 'getCredentials').mockRejectedValueOnce(undefined);
-    await store.dispatch(auth.checkLoginStatus());
+    const error = new Error('not logged in');
+    error.stack = undefined; // makes test failure messsages messy
+
+    jest.spyOn(auth0, 'getCredentials').mockRejectedValueOnce(error);
+    await store.dispatch(user.checkLoginStatus());
     const userState = store.getState().user;
     expect(userState).toEqual({
+      action: 'checkLoginStatus',
       status: 'rejected',
-      reason: 'NOT_LOGGED_IN',
-      accessToken: '',
-      email: '',
+      reason: 'AUTH_UTIL_REJECTED',
+      error: miniSerializeError(error),
     });
   });
 
   it('should check if a user IS logged in', async () => {
-    await store.dispatch(auth.checkLoginStatus());
+    await store.dispatch(user.checkLoginStatus());
     const userState = store.getState().user;
     expect(userState).toEqual({
+      action: 'checkLoginStatus',
       status: 'fulfilled',
       accessToken: 'test token',
       email: 'test email',
@@ -87,27 +94,32 @@ describe('user store', () => {
 
   it('should handle login error', async () => {
     const authorizeError = new Error('login failed');
+    authorizeError.stack = undefined; // makes test failure messsages messy
+
     jest.spyOn(auth0, 'authorize').mockRejectedValue(authorizeError);
-    await store.dispatch(auth.login());
+    await store.dispatch(user.login());
     const userState = store.getState().user;
     expect(userState).toEqual({
+      action: 'login',
       status: 'rejected',
-      error: authorizeError,
-      reason: 'LOGIN_ERROR',
+      error: miniSerializeError(authorizeError),
+      reason: 'AUTH_UTIL_REJECTED',
     });
   });
 
   it('should handle logout error', async () => {
-    jest
-      .spyOn(auth0, 'clearSession')
-      .mockRejectedValue(new Error('logout failed'));
-    await store.dispatch(auth.login());
-    await store.dispatch(auth.logout());
+    const error = new Error('logout failed');
+    error.stack = undefined;
+
+    jest.spyOn(auth0, 'clearSession').mockRejectedValue(error);
+    await store.dispatch(user.login());
+    await store.dispatch(user.logout());
     const userState = store.getState().user;
     expect(userState).toEqual({
+      action: 'logout',
       status: 'rejected',
-      error: new Error('logout failed'),
-      reason: 'LOGOUT_ERROR',
+      error: miniSerializeError(error),
+      reason: 'AUTH_UTIL_REJECTED',
     });
   });
 });

--- a/app/src/store/__tests__/user.test.ts
+++ b/app/src/store/__tests__/user.test.ts
@@ -76,7 +76,7 @@ describe('user store', () => {
     expect(userState).toEqual({
       action: 'checkLoginStatus',
       status: 'rejected',
-      reason: 'AUTH_UTIL_REJECTED',
+      reason: 'AUTH_REJECTED',
       error: miniSerializeError(error),
     });
   });
@@ -103,7 +103,7 @@ describe('user store', () => {
       action: 'login',
       status: 'rejected',
       error: miniSerializeError(authorizeError),
-      reason: 'AUTH_UTIL_REJECTED',
+      reason: 'AUTH_REJECTED',
     });
   });
 
@@ -119,7 +119,7 @@ describe('user store', () => {
       action: 'logout',
       status: 'rejected',
       error: miniSerializeError(error),
-      reason: 'AUTH_UTIL_REJECTED',
+      reason: 'AUTH_REJECTED',
     });
   });
 });

--- a/app/src/store/__tests__/voice/call/activeCall.test.ts
+++ b/app/src/store/__tests__/voice/call/activeCall.test.ts
@@ -4,7 +4,7 @@ import { createStore, type Store } from '../../../app';
 import * as activeCall from '../../../voice/call/activeCall';
 import { makeOutgoingCall } from '../../../voice/call/outgoingCall';
 import { getAccessToken } from '../../../voice/accessToken';
-import { login } from '../../../../util/auth';
+import { login } from '../../../user';
 import * as mockVoiceSdk from '../../../../../__mocks__/@twilio/voice-react-native-sdk';
 
 jest.mock('../../../../util/fetch', () => ({

--- a/app/src/store/__tests__/voice/call/outgoingCall.test.ts
+++ b/app/src/store/__tests__/voice/call/outgoingCall.test.ts
@@ -3,7 +3,7 @@ import { match, P } from 'ts-pattern';
 import { createStore, type Store } from '../../../app';
 import { makeOutgoingCall } from '../../../voice/call/outgoingCall';
 import { getAccessToken } from '../../../voice/accessToken';
-import { login } from '../../../../util/auth';
+import { login } from '../../../user';
 import * as mockVoiceSdk from '../../../../../__mocks__/@twilio/voice-react-native-sdk';
 import * as voiceUtil from '../../../../util/voice';
 

--- a/app/src/store/bootstrap.ts
+++ b/app/src/store/bootstrap.ts
@@ -5,7 +5,7 @@ import {
 } from '@reduxjs/toolkit';
 import { Voice, CallInvite } from '@twilio/voice-react-native-sdk';
 import { createTypedAsyncThunk, generateThunkActionTypes } from './common';
-import { checkLoginStatus } from '../util/auth';
+import { checkLoginStatus } from './user';
 import { getAccessToken } from './voice/accessToken';
 import { getCallInviteInfo } from './voice/call';
 import { setCallInvite } from './voice/call/callInvite';

--- a/app/src/store/user.ts
+++ b/app/src/store/user.ts
@@ -15,7 +15,7 @@ export const sliceName = 'user' as const;
  * Reusable type for all actions.
  */
 export type RejectValue = {
-  reason: 'AUTH_UTIL_REJECTED';
+  reason: 'AUTH_REJECTED';
   error: SerializedError;
 };
 
@@ -33,7 +33,7 @@ export const checkLoginStatus = createTypedAsyncThunk<
   const checkLoginStatusResult = await settlePromise(auth.checkLoginStatus());
   if (checkLoginStatusResult.status === 'rejected') {
     return rejectWithValue({
-      reason: 'AUTH_UTIL_REJECTED',
+      reason: 'AUTH_REJECTED',
       error: miniSerializeError(checkLoginStatusResult.reason),
     });
   }
@@ -53,7 +53,7 @@ export const login = createTypedAsyncThunk<
   const loginResult = await settlePromise(auth.login());
   if (loginResult.status === 'rejected') {
     return rejectWithValue({
-      reason: 'AUTH_UTIL_REJECTED',
+      reason: 'AUTH_REJECTED',
       error: miniSerializeError(loginResult.reason),
     });
   }
@@ -75,7 +75,7 @@ export const logout = createTypedAsyncThunk<
   const clearSessionResult = await settlePromise(auth.logout());
   if (clearSessionResult.status === 'rejected') {
     return rejectWithValue({
-      reason: 'AUTH_UTIL_REJECTED',
+      reason: 'AUTH_REJECTED',
       error: miniSerializeError(clearSessionResult.reason),
     });
   }
@@ -117,7 +117,7 @@ export const userSlice = createSlice({
       const { requestStatus } = action.meta;
 
       return match(action.payload)
-        .with({ reason: 'AUTH_UTIL_REJECTED' }, ({ reason, error }) => ({
+        .with({ reason: 'AUTH_REJECTED' }, ({ reason, error }) => ({
           action: actionType,
           status: requestStatus,
           reason,
@@ -153,7 +153,7 @@ export const userSlice = createSlice({
       const { requestStatus } = action.meta;
 
       return match(action.payload)
-        .with({ reason: 'AUTH_UTIL_REJECTED' }, ({ reason, error }) => ({
+        .with({ reason: 'AUTH_REJECTED' }, ({ reason, error }) => ({
           action: actionType,
           status: requestStatus,
           reason,
@@ -187,7 +187,7 @@ export const userSlice = createSlice({
       const { requestStatus } = action.meta;
 
       return match(action.payload)
-        .with({ reason: 'AUTH_UTIL_REJECTED' }, ({ reason, error }) => ({
+        .with({ reason: 'AUTH_REJECTED' }, ({ reason, error }) => ({
           action: actionType,
           status: requestStatus,
           reason,

--- a/app/src/store/user.ts
+++ b/app/src/store/user.ts
@@ -1,70 +1,204 @@
-import { createSlice } from '@reduxjs/toolkit';
+import {
+  createSlice,
+  miniSerializeError,
+  type SerializedError,
+} from '@reduxjs/toolkit';
+import { match } from 'ts-pattern';
 import { type AsyncStoreSlice } from './app';
-import * as auth from '../util/auth';
+import { createTypedAsyncThunk, generateThunkActionTypes } from './common';
+import { auth } from '../util/auth';
+import { settlePromise } from '../util/settlePromise';
 
-export type UserState = AsyncStoreSlice<
-  {
-    accessToken: string;
-    email: string;
-  },
-  {
-    reason:
-      | 'ID_TOKEN_UNDEFINED'
-      | 'LOGIN_ERROR'
-      | 'LOGOUT_ERROR'
-      | 'NOT_LOGGED_IN'
-      | undefined;
-    error?: any;
+export const sliceName = 'user' as const;
+
+/**
+ * Reusable type for all actions.
+ */
+export type RejectValue = {
+  reason: 'AUTH_UTIL_REJECTED';
+  error: SerializedError;
+};
+
+/**
+ * Check login status action.
+ */
+export const checkLoginStatusActionTypes = generateThunkActionTypes(
+  `${sliceName}/checkLoginStatus`,
+);
+export const checkLoginStatus = createTypedAsyncThunk<
+  { accessToken: string; email: string },
+  void,
+  { rejectValue: RejectValue }
+>(checkLoginStatusActionTypes.prefix, async (_, { rejectWithValue }) => {
+  const checkLoginStatusResult = await settlePromise(auth.checkLoginStatus());
+  if (checkLoginStatusResult.status === 'rejected') {
+    return rejectWithValue({
+      reason: 'AUTH_UTIL_REJECTED',
+      error: miniSerializeError(checkLoginStatusResult.reason),
+    });
   }
->;
+
+  return checkLoginStatusResult.value;
+});
+
+/**
+ * Login action.
+ */
+export const loginActionTypes = generateThunkActionTypes(`${sliceName}/login`);
+export const login = createTypedAsyncThunk<
+  { accessToken: string; email: string },
+  void,
+  { rejectValue: RejectValue }
+>(loginActionTypes.prefix, async (_, { rejectWithValue }) => {
+  const loginResult = await settlePromise(auth.login());
+  if (loginResult.status === 'rejected') {
+    return rejectWithValue({
+      reason: 'AUTH_UTIL_REJECTED',
+      error: miniSerializeError(loginResult.reason),
+    });
+  }
+
+  return loginResult.value;
+});
+
+/**
+ * Logout action.
+ */
+export const logoutActionTypes = generateThunkActionTypes(
+  `${sliceName}/logout`,
+);
+export const logout = createTypedAsyncThunk<
+  void,
+  void,
+  { rejectValue: RejectValue }
+>(logoutActionTypes.prefix, async (_, { rejectWithValue }) => {
+  const clearSessionResult = await settlePromise(auth.logout());
+  if (clearSessionResult.status === 'rejected') {
+    return rejectWithValue({
+      reason: 'AUTH_UTIL_REJECTED',
+      error: miniSerializeError(clearSessionResult.reason),
+    });
+  }
+});
+
+/**
+ * User slice configuration.
+ */
+type UserRejectState = RejectValue | { error: SerializedError };
+
+export type UserState = {
+  action: 'checkLoginStatus' | 'login' | 'logout';
+} & AsyncStoreSlice<{ accessToken: string; email: string }, UserRejectState>;
 
 export const userSlice = createSlice({
   name: 'user',
   initialState: { status: 'idle' } as UserState,
   reducers: {},
   extraReducers: (builder) => {
-    builder
-      .addCase(auth.checkLoginStatus.pending, () => {
-        return { status: 'pending' };
-      })
-      .addCase(auth.checkLoginStatus.fulfilled, (_, action) => {
-        return { status: 'fulfilled', ...action.payload };
-      })
-      .addCase(auth.checkLoginStatus.rejected, (_, action) => {
-        return {
-          status: 'rejected',
-          reason: action.payload?.reason,
-          accessToken: '',
-          email: '',
-        };
-      });
-    builder
-      .addCase(auth.login.pending, () => {
-        return { status: 'pending' };
-      })
-      .addCase(auth.login.fulfilled, (_, action) => {
-        return { status: 'fulfilled', ...action.payload };
-      })
-      .addCase(auth.login.rejected, (_, action) => {
-        return {
-          status: 'rejected',
-          reason: action.payload?.reason,
-          error: action.payload?.error || action.error,
-        };
-      });
-    builder
-      .addCase(auth.logout.pending, () => {
-        return { status: 'pending' };
-      })
-      .addCase(auth.logout.fulfilled, (_, action) => {
-        return { status: 'fulfilled', ...action.payload };
-      })
-      .addCase(auth.logout.rejected, (_, action) => {
-        return {
-          status: 'rejected',
-          reason: action.payload?.reason,
-          error: action.payload?.error,
-        };
-      });
+    /**
+     * Check login action handling.
+     */
+    builder.addCase(checkLoginStatus.pending, () => {
+      return { action: 'checkLoginStatus', status: 'pending' };
+    });
+
+    builder.addCase(checkLoginStatus.fulfilled, (_, action) => {
+      return {
+        action: 'checkLoginStatus',
+        status: 'fulfilled',
+        accessToken: action.payload.accessToken,
+        email: action.payload.email,
+      };
+    });
+
+    builder.addCase(checkLoginStatus.rejected, (_, action) => {
+      const actionType = 'checkLoginStatus' as const;
+
+      const { requestStatus } = action.meta;
+
+      return match(action.payload)
+        .with({ reason: 'AUTH_UTIL_REJECTED' }, ({ reason, error }) => ({
+          action: actionType,
+          status: requestStatus,
+          reason,
+          error,
+        }))
+        .with(undefined, () => ({
+          action: actionType,
+          status: requestStatus,
+          error: action.error,
+        }))
+        .exhaustive();
+    });
+
+    /**
+     * Login action handling.
+     */
+    builder.addCase(login.pending, () => {
+      return { action: 'login', status: 'pending' };
+    });
+
+    builder.addCase(login.fulfilled, (_, action) => {
+      return {
+        action: 'login',
+        status: 'fulfilled',
+        accessToken: action.payload.accessToken,
+        email: action.payload.email,
+      };
+    });
+
+    builder.addCase(login.rejected, (_, action) => {
+      const actionType = 'login' as const;
+
+      const { requestStatus } = action.meta;
+
+      return match(action.payload)
+        .with({ reason: 'AUTH_UTIL_REJECTED' }, ({ reason, error }) => ({
+          action: actionType,
+          status: requestStatus,
+          reason,
+          error,
+        }))
+        .with(undefined, () => ({
+          action: actionType,
+          status: requestStatus,
+          error: action.error,
+        }))
+        .exhaustive();
+    });
+
+    /**
+     * Logout action handling.
+     */
+    builder.addCase(logout.pending, () => {
+      return { action: 'logout', status: 'pending' };
+    });
+    builder.addCase(logout.fulfilled, () => {
+      return {
+        action: 'logout',
+        status: 'fulfilled',
+        accessToken: '',
+        email: '',
+      };
+    });
+    builder.addCase(logout.rejected, (_, action) => {
+      const actionType = 'logout' as const;
+
+      const { requestStatus } = action.meta;
+
+      match(action.payload)
+        .with({ reason: 'AUTH_UTIL_REJECTED' }, ({ reason, error }) => ({
+          action: actionType,
+          status: requestStatus,
+          reason,
+          error,
+        }))
+        .with(undefined, () => ({
+          action: actionType,
+          status: requestStatus,
+          error: action.error,
+        }))
+        .exhaustive();
+    });
   },
 });

--- a/app/src/store/user.ts
+++ b/app/src/store/user.ts
@@ -186,7 +186,7 @@ export const userSlice = createSlice({
 
       const { requestStatus } = action.meta;
 
-      match(action.payload)
+      return match(action.payload)
         .with({ reason: 'AUTH_UTIL_REJECTED' }, ({ reason, error }) => ({
           action: actionType,
           status: requestStatus,

--- a/app/src/store/voice/registration.ts
+++ b/app/src/store/voice/registration.ts
@@ -4,12 +4,12 @@ import {
   type SerializedError,
 } from '@reduxjs/toolkit';
 import { match } from 'ts-pattern';
-import { AsyncStoreSlice } from '../app';
-import { voice } from '../../util/voice';
-import { settlePromise } from '../../util/settlePromise';
-import { login } from '../../util/auth';
 import { getAccessToken } from './accessToken';
+import { type AsyncStoreSlice } from '../app';
 import { createTypedAsyncThunk } from '../common';
+import { login } from '../user';
+import { settlePromise } from '../../util/settlePromise';
+import { voice } from '../../util/voice';
 
 export type RegisterRejectValue =
   | {


### PR DESCRIPTION
## Submission Checklist

 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] New unit tests and integration tests have beed added
 - [x] Code coverage is more or equal to the previous coverage
 - [x] A visual inspection of the `Files changed` tab was made prior to submitting the pull request ensuring the style guide was followed
 - [ ] [CI pipeline](https://app.circleci.com/pipelines/github/twilio/twilio-voice-react-native-app) is green
 - [x] ~Included screenshot if necessary~

## Description

Move user actions into the store and have clean separation of concerns for auth libraries in the auth util. With these changes, a fork of this project can reasonably replace solely the auth util with their own implementation and not have to change the store.

## Breakdown

- Move auth0 related functions to auth util
- Use auth util in the user store actions
- Adjust imports and unit tests

## Validation

- Unit tests
- Manual testing

## Additional Notes

N/A

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
