### PR TITLE
[VBLOCKS-1973] Fix: show busy during login and register

### DIFF
--- a/app/src/screens/SignIn/index.tsx
+++ b/app/src/screens/SignIn/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, View, Image, Text, TouchableOpacity } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
-import { loginAndRegister } from '../../store/voice/registration';
+import { loginAndRegister } from '../../store/loginAndRegister';
 import { type Dispatch, type State } from '../../store/app';
 
 const ArrowForward = require('../../../assets/icons/arrow-forward.png');

--- a/app/src/screens/StackNavigator.tsx
+++ b/app/src/screens/StackNavigator.tsx
@@ -14,15 +14,23 @@ const Stack = createNativeStackNavigator<StackParamList>();
 
 const StackNavigator = () => {
   const user = useSelector((state: State) => state.user);
+  const loginAndRegister = useSelector(
+    (state: State) => state.loginAndRegister,
+  );
+
+  const isLoggedIn =
+    user?.status === 'fulfilled' &&
+    user.accessToken &&
+    loginAndRegister?.status === 'fulfilled';
+
   if (user === null) {
     return <Text>Application not bootstrapped.</Text>;
   }
 
-  if (user?.status === 'pending') {
+  if (loginAndRegister?.status === 'pending') {
     return <Busy />;
   }
 
-  const isLoggedIn = user?.status === 'fulfilled' && user.accessToken;
   if (!isLoggedIn) {
     return <SignIn />;
   }

--- a/app/src/screens/__tests__/ActiveCall.test.tsx
+++ b/app/src/screens/__tests__/ActiveCall.test.tsx
@@ -68,6 +68,9 @@ describe('<ActiveCall />', () => {
         status: 'idle',
         action: 'login',
       },
+      loginAndRegister: {
+        status: 'idle',
+      },
     };
 
     const store = mockStore(initialState);

--- a/app/src/store/__tests__/registration.test.ts
+++ b/app/src/store/__tests__/registration.test.ts
@@ -3,6 +3,7 @@ import { createStore, Store } from '../app';
 import * as user from '../user';
 import * as accessTokenStoreModule from '../voice/accessToken';
 import * as registrationStoreModule from '../voice/registration';
+import * as loginAndRegisterModule from '../loginAndRegister';
 import * as auth0 from '../../../__mocks__/react-native-auth0';
 import * as voiceSdk from '../../../__mocks__/@twilio/voice-react-native-sdk';
 import * as fetchUtil from '../../util/fetch';
@@ -48,7 +49,7 @@ describe('registration', () => {
   describe('loginAndRegister', () => {
     it('resolves when all sub-actions resolve', async () => {
       const loginAndRegisterResult = await store.dispatch(
-        registrationStoreModule.loginAndRegister(),
+        loginAndRegisterModule.loginAndRegister(),
       );
       expect(loginAndRegisterResult.type).toEqual(
         'registration/loginAndRegister/fulfilled',
@@ -56,14 +57,14 @@ describe('registration', () => {
       expect(loginAndRegisterResult.payload).toEqual(undefined);
 
       matchDispatchedActions(dispatchedActions, [
-        registrationStoreModule.loginAndRegister.pending,
+        loginAndRegisterModule.loginAndRegister.pending,
         user.login.pending,
         user.login.fulfilled,
         accessTokenStoreModule.getAccessToken.pending,
         accessTokenStoreModule.getAccessToken.fulfilled,
         registrationStoreModule.register.pending,
         registrationStoreModule.register.fulfilled,
-        registrationStoreModule.loginAndRegister.fulfilled,
+        loginAndRegisterModule.loginAndRegister.fulfilled,
       ]);
     });
 
@@ -72,7 +73,7 @@ describe('registration', () => {
         jest.spyOn(auth0, 'authorize').mockRejectedValueOnce(undefined);
 
         const loginAndRegisterResult = await store.dispatch(
-          registrationStoreModule.loginAndRegister(),
+          loginAndRegisterModule.loginAndRegister(),
         );
         expect(loginAndRegisterResult.type).toEqual(
           'registration/loginAndRegister/rejected',
@@ -82,10 +83,10 @@ describe('registration', () => {
         });
 
         matchDispatchedActions(dispatchedActions, [
-          registrationStoreModule.loginAndRegister.pending,
+          loginAndRegisterModule.loginAndRegister.pending,
           user.login.pending,
           user.login.rejected,
-          registrationStoreModule.loginAndRegister.rejected,
+          loginAndRegisterModule.loginAndRegister.rejected,
         ]);
       });
 
@@ -93,7 +94,7 @@ describe('registration', () => {
         fetchMock.mockRejectedValueOnce(undefined);
 
         const loginAndRegisterResult = await store.dispatch(
-          registrationStoreModule.loginAndRegister(),
+          loginAndRegisterModule.loginAndRegister(),
         );
         expect(loginAndRegisterResult.type).toEqual(
           'registration/loginAndRegister/rejected',
@@ -103,14 +104,14 @@ describe('registration', () => {
         });
 
         matchDispatchedActions(dispatchedActions, [
-          registrationStoreModule.loginAndRegister.pending,
+          loginAndRegisterModule.loginAndRegister.pending,
           user.login.pending,
           user.login.fulfilled,
           accessTokenStoreModule.getAccessToken.pending,
           accessTokenStoreModule.getAccessToken.rejected,
           user.logout.pending,
           user.logout.fulfilled,
-          registrationStoreModule.loginAndRegister.rejected,
+          loginAndRegisterModule.loginAndRegister.rejected,
         ]);
       });
 
@@ -118,7 +119,7 @@ describe('registration', () => {
         voiceSdk.voiceRegister.mockRejectedValueOnce(undefined);
 
         const loginAndRegisterResult = await store.dispatch(
-          registrationStoreModule.loginAndRegister(),
+          loginAndRegisterModule.loginAndRegister(),
         );
         expect(loginAndRegisterResult.type).toEqual(
           'registration/loginAndRegister/rejected',
@@ -128,14 +129,14 @@ describe('registration', () => {
         });
 
         matchDispatchedActions(dispatchedActions, [
-          registrationStoreModule.loginAndRegister.pending,
+          loginAndRegisterModule.loginAndRegister.pending,
           user.login.pending,
           user.login.fulfilled,
           accessTokenStoreModule.getAccessToken.pending,
           accessTokenStoreModule.getAccessToken.fulfilled,
           registrationStoreModule.register.pending,
           registrationStoreModule.register.rejected,
-          registrationStoreModule.loginAndRegister.rejected,
+          loginAndRegisterModule.loginAndRegister.rejected,
         ]);
       });
 
@@ -155,7 +156,7 @@ describe('registration', () => {
             text: jest.fn().mockResolvedValue(''),
           }),
         );
-        await store.dispatch(registrationStoreModule.loginAndRegister());
+        await store.dispatch(loginAndRegisterModule.loginAndRegister());
         const register = await store.dispatch(
           registrationStoreModule.register(),
         );

--- a/app/src/store/__tests__/registration.test.ts
+++ b/app/src/store/__tests__/registration.test.ts
@@ -51,9 +51,7 @@ describe('registration', () => {
       const loginAndRegisterResult = await store.dispatch(
         loginAndRegisterModule.loginAndRegister(),
       );
-      expect(loginAndRegisterResult.type).toEqual(
-        'registration/loginAndRegister/fulfilled',
-      );
+      expect(loginAndRegisterResult.type).toEqual('loginAndRegister/fulfilled');
       expect(loginAndRegisterResult.payload).toEqual(undefined);
 
       matchDispatchedActions(dispatchedActions, [
@@ -76,7 +74,7 @@ describe('registration', () => {
           loginAndRegisterModule.loginAndRegister(),
         );
         expect(loginAndRegisterResult.type).toEqual(
-          'registration/loginAndRegister/rejected',
+          'loginAndRegister/rejected',
         );
         expect(loginAndRegisterResult.payload).toEqual({
           reason: 'LOGIN_REJECTED',
@@ -97,7 +95,7 @@ describe('registration', () => {
           loginAndRegisterModule.loginAndRegister(),
         );
         expect(loginAndRegisterResult.type).toEqual(
-          'registration/loginAndRegister/rejected',
+          'loginAndRegister/rejected',
         );
         expect(loginAndRegisterResult.payload).toEqual({
           reason: 'GET_ACCESS_TOKEN_REJECTED',
@@ -122,7 +120,7 @@ describe('registration', () => {
           loginAndRegisterModule.loginAndRegister(),
         );
         expect(loginAndRegisterResult.type).toEqual(
-          'registration/loginAndRegister/rejected',
+          'loginAndRegister/rejected',
         );
         expect(loginAndRegisterResult.payload).toEqual({
           reason: 'REGISTER_REJECTED',

--- a/app/src/store/app.ts
+++ b/app/src/store/app.ts
@@ -1,10 +1,12 @@
 import { configureStore, type Middleware } from '@reduxjs/toolkit';
 import { voiceReducer } from './voice';
 import { userSlice } from './user';
+import { loginAndRegisterSlice } from './loginAndRegister';
 import { createLogMiddleware } from './middleware/log';
 
 export const defaultReducer = {
   [userSlice.name]: userSlice.reducer,
+  [loginAndRegisterSlice.name]: loginAndRegisterSlice.reducer,
   voice: voiceReducer,
 };
 

--- a/app/src/store/loginAndRegister.ts
+++ b/app/src/store/loginAndRegister.ts
@@ -1,0 +1,80 @@
+import { createSlice, type SerializedError } from '@reduxjs/toolkit';
+import { match } from 'ts-pattern';
+import { getAccessToken } from './voice/accessToken';
+import { register } from './voice/registration';
+import { type AsyncStoreSlice } from './app';
+import { createTypedAsyncThunk } from './common';
+import { login, logout } from './user';
+
+export type LoginAndRegisterRejectValue =
+  | {
+      reason: 'LOGIN_REJECTED';
+    }
+  | {
+      reason: 'GET_ACCESS_TOKEN_REJECTED';
+    }
+  | {
+      reason: 'REGISTER_REJECTED';
+    };
+
+export const loginAndRegister = createTypedAsyncThunk<
+  void,
+  void,
+  {
+    rejectValue: LoginAndRegisterRejectValue;
+  }
+>('registration/loginAndRegister', async (_, { dispatch, rejectWithValue }) => {
+  const loginActionResult = await dispatch(login());
+  if (login.rejected.match(loginActionResult)) {
+    return rejectWithValue({ reason: 'LOGIN_REJECTED' });
+  }
+
+  const getAccessTokenResult = await dispatch(getAccessToken());
+  if (getAccessToken.rejected.match(getAccessTokenResult)) {
+    await dispatch(logout());
+    return rejectWithValue({
+      reason: 'GET_ACCESS_TOKEN_REJECTED',
+    });
+  }
+
+  const registerActionResult = await dispatch(register());
+  if (register.rejected.match(registerActionResult)) {
+    return rejectWithValue({ reason: 'REGISTER_REJECTED' });
+  }
+});
+
+export type LoginAndRegisterSlice = AsyncStoreSlice<
+  {},
+  LoginAndRegisterRejectValue | { error: SerializedError }
+>;
+
+export const loginAndRegisterSlice = createSlice({
+  name: 'loginAndRegister',
+  initialState: { status: 'idle' } as LoginAndRegisterSlice,
+  reducers: {},
+  extraReducers(builder) {
+    builder.addCase(loginAndRegister.pending, () => ({ status: 'pending' }));
+
+    builder.addCase(loginAndRegister.fulfilled, () => ({
+      status: 'fulfilled',
+    }));
+
+    builder.addCase(loginAndRegister.rejected, (_, action) => {
+      const { requestStatus } = action.meta;
+
+      return match(action.payload)
+        .with(
+          { reason: 'LOGIN_REJECTED' },
+          { reason: 'GET_ACCESS_TOKEN_REJECTED' },
+          { reason: 'REGISTER_REJECTED' },
+          ({ reason }) => ({ status: requestStatus, reason }),
+        )
+        .with(undefined, () => ({
+          status: requestStatus,
+          error: action.error,
+          reason: 'UNEXPECTED_ERROR',
+        }))
+        .exhaustive();
+    });
+  },
+});

--- a/app/src/store/voice/registration.ts
+++ b/app/src/store/voice/registration.ts
@@ -4,10 +4,8 @@ import {
   type SerializedError,
 } from '@reduxjs/toolkit';
 import { match } from 'ts-pattern';
-import { getAccessToken } from './accessToken';
 import { type AsyncStoreSlice } from '../app';
 import { createTypedAsyncThunk } from '../common';
-import { login, logout } from '../user';
 import { settlePromise } from '../../util/settlePromise';
 import { voice } from '../../util/voice';
 
@@ -48,43 +46,6 @@ export const register = createTypedAsyncThunk<
       reason: 'NATIVE_MODULE_REJECTED',
       error: miniSerializeError(voiceRegisterResult.reason),
     });
-  }
-});
-
-export type LoginAndRegisterRejectValue =
-  | {
-      reason: 'LOGIN_REJECTED';
-    }
-  | {
-      reason: 'GET_ACCESS_TOKEN_REJECTED';
-    }
-  | {
-      reason: 'REGISTER_REJECTED';
-    };
-
-export const loginAndRegister = createTypedAsyncThunk<
-  void,
-  void,
-  {
-    rejectValue: LoginAndRegisterRejectValue;
-  }
->('registration/loginAndRegister', async (_, { dispatch, rejectWithValue }) => {
-  const loginActionResult = await dispatch(login());
-  if (login.rejected.match(loginActionResult)) {
-    return rejectWithValue({ reason: 'LOGIN_REJECTED' });
-  }
-
-  const getAccessTokenResult = await dispatch(getAccessToken());
-  if (getAccessToken.rejected.match(getAccessTokenResult)) {
-    await dispatch(logout());
-    return rejectWithValue({
-      reason: 'GET_ACCESS_TOKEN_REJECTED',
-    });
-  }
-
-  const registerActionResult = await dispatch(register());
-  if (register.rejected.match(registerActionResult)) {
-    return rejectWithValue({ reason: 'REGISTER_REJECTED' });
   }
 });
 


### PR DESCRIPTION
## Submission Checklist

 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] New unit tests and integration tests have beed added
 - [x] Code coverage is more or equal to the previous coverage
 - [x] A visual inspection of the `Files changed` tab was made prior to submitting the pull request ensuring the style guide was followed
 - [ ] [CI pipeline](https://app.circleci.com/pipelines/github/twilio/twilio-voice-react-native-app) is green
 - [ ] Included screenshot if necessary

## Description

[VBLOCKS-1973](https://issues.corp.twilio.com/browse/VBLOCKS-1973)

### Breakdown

- Add Slice for LoginAndRegister asyncThunk
- Allows us to show busy UI for `login`, `getAccessToken` and `register` steps

## Validation

- local testing

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

## Contributing to Twilio

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
