### PR TITLE
[VBLOCKS-2081] Persist outgoing client identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@
   * Minimum supported version for iOS is 13
 
 ### Fixes
-* The call state and duration are now persisted between JS runtimes.
+* The call state, duration and outgoing parameters are now persisted between JS
+runtimes.
   * In effect, on Android, if a user is in an active call and closes the app,
   when they reopen the app while still in the active call, it will show the
-  proper call duration and state.
+  proper call duration, state, and outgoing call parameters (such as identity).
 
 ## Server
 

--- a/app/__mocks__/@react-native-async-storage/async-storage.ts
+++ b/app/__mocks__/@react-native-async-storage/async-storage.ts
@@ -1,0 +1,33 @@
+export const keyValueStore = new Map();
+
+export const setItem = jest
+  .fn()
+  .mockImplementation(
+    async (key: string, value: string, _cb?: (error?: Error) => void) => {
+      keyValueStore.set(key, value);
+    },
+  );
+
+export const getItem = jest
+  .fn()
+  .mockImplementation(async (key: string, _cb?: (error?: Error) => void) => {
+    return keyValueStore.get(key);
+  });
+
+export const getAllKeys = jest.fn().mockImplementation(async () => {
+  return Array.from(keyValueStore.keys());
+});
+
+export const removeItem = jest.fn().mockImplementation(async (k: string) => {
+  keyValueStore.delete(k);
+});
+
+export const multiRemove = jest
+  .fn()
+  .mockImplementation(async (keys: string[]) => {
+    for (const k of keys) {
+      keyValueStore.delete(k);
+    }
+  });
+
+export default { setItem, getItem, getAllKeys, multiRemove, removeItem };

--- a/app/__mocks__/@twilio/voice-react-native-sdk.ts
+++ b/app/__mocks__/@twilio/voice-react-native-sdk.ts
@@ -137,6 +137,7 @@ export const Voice = jest.fn().mockImplementation(() => {
     connect: voiceConnect,
     emit,
     getCallInvites: voiceGetCallInvites,
+    getCalls: voiceGetCalls,
     initializePushRegistry: voiceInitializePushRegistry,
     on,
     once,

--- a/app/__mocks__/@twilio/voice-react-native-sdk.ts
+++ b/app/__mocks__/@twilio/voice-react-native-sdk.ts
@@ -6,7 +6,12 @@ export const voiceConnect = jest.fn(async () =>
   createMockCall(`${callUuid++}`),
 );
 
+export const voiceGetCalls = jest.fn(() => {
+  return Promise.resolve(new Map());
+});
+
 export const createMockCall = jest.fn((id: string) => {
+  const listeners: Map<string, ((...args: any[]) => any)[]> = new Map();
   const mockCall = {
     _uuid: `mock uuid ${id}`,
     disconnect: jest.fn().mockResolvedValue(undefined),
@@ -23,8 +28,43 @@ export const createMockCall = jest.fn((id: string) => {
     getTo: jest.fn().mockReturnValue(`mock to ${id}`),
     isMuted: jest.fn().mockReturnValue(false),
     isOnHold: jest.fn().mockReturnValue(false),
-    on: jest.fn(),
-    once: jest.fn(),
+    on: jest
+      .fn()
+      .mockImplementation(
+        (event: string, listener: (...args: any[]) => void) => {
+          const newListeners = listeners.has(event)
+            ? [...listeners.get(event)!, listener]
+            : [listener];
+          listeners.set(event, newListeners);
+        },
+      ),
+    once: jest
+      .fn()
+      .mockImplementation(
+        (event: string, listener: (...args: any[]) => void) => {
+          let didWrappedListenerFire = false;
+          const wrappedListener = (...argsPrime: any[]) => {
+            if (didWrappedListenerFire) {
+              return;
+            }
+            didWrappedListenerFire = true;
+            listener(...argsPrime);
+          };
+          const newListeners = listeners.has(event)
+            ? [...listeners.get(event)!, wrappedListener]
+            : [wrappedListener];
+          listeners.set(event, newListeners);
+        },
+      ),
+    emit: (event: string, ...args: any[]) => {
+      const eventListeners = listeners.get(event);
+      if (!eventListeners) {
+        return;
+      }
+      for (const listener of eventListeners) {
+        listener(...args);
+      }
+    },
   };
   return mockCall;
 });
@@ -57,6 +97,7 @@ let callUuid = 0;
 
 export const Voice = jest.fn().mockReturnValue({
   connect: voiceConnect,
+  getCalls: voiceGetCalls,
   getCallInvites: voiceGetCallInvites,
   initializePushRegistry: voiceInitializePushRegistry,
   on: voiceOn,

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
     "detox:test": "detox test"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.19.2",
     "@react-navigation/bottom-tabs": "^6.5.3",
     "@react-navigation/native": "^6.1.2",
     "@react-navigation/native-stack": "^6.9.8",

--- a/app/src/hooks/activeCall.ts
+++ b/app/src/hooks/activeCall.ts
@@ -98,7 +98,7 @@ export const useActiveCallRemoteParticipant = (
           { direction: 'incoming', status: 'fulfilled' },
           (c) => c.info.from || '',
         )
-        .with({ direction: 'outgoing' }, (c) => c.to)
+        .with({ direction: 'outgoing' }, (c) => c.params.to)
         .otherwise(() => ''),
     [activeCall],
   );

--- a/app/src/screens/__tests__/ActiveCall.test.tsx
+++ b/app/src/screens/__tests__/ActiveCall.test.tsx
@@ -104,8 +104,10 @@ describe('<ActiveCall />', () => {
                   state: 'connected',
                   initialConnectedTimestamp: 42,
                 },
-                recipientType: 'client',
-                to: 'foobar-outgoing-client-to',
+                params: {
+                  recipientType: 'client',
+                  to: 'foobar-outgoing-client-to',
+                },
                 direction: 'outgoing',
                 status: 'fulfilled',
               },

--- a/app/src/store/__tests__/bootstrap.test.ts
+++ b/app/src/store/__tests__/bootstrap.test.ts
@@ -4,6 +4,7 @@ import {
   bootstrapPushRegistry,
   bootstrapUser,
   bootstrapCallInvites,
+  bootstrapCalls,
 } from '../bootstrap';
 import { checkLoginStatus } from '../user';
 import { getAccessToken } from '../voice/accessToken';
@@ -11,6 +12,7 @@ import { receiveCallInvite, setCallInvite } from '../voice/call/callInvite';
 import { register } from '../voice/registration';
 import * as auth0 from '../../../__mocks__/react-native-auth0';
 import * as voiceSdk from '../../../__mocks__/@twilio/voice-react-native-sdk';
+import * as asyncStorage from '../../../__mocks__/@react-native-async-storage/async-storage';
 
 let fetchMock: jest.Mock;
 let mockPlatform: {
@@ -246,6 +248,76 @@ describe('bootstrap', () => {
         receiveCallInvite.fulfilled,
         receiveCallInvite.fulfilled,
         bootstrapCallInvites.fulfilled,
+      ]);
+    });
+  });
+
+  describe('bootstrapCalls', () => {
+    // TODO(mhuynh): [VBLOCKS-2078] Increase coverage.
+
+    beforeEach(() => {
+      voiceSdk.voiceGetCalls.mockImplementationOnce(() => {
+        return Promise.resolve(new Map([['1', voiceSdk.createMockCall('1')]]));
+      });
+      asyncStorage.keyValueStore.clear();
+      const mockAsyncStorage = [
+        [
+          'mock sid 1',
+          JSON.stringify({ to: 'foo to', recipientType: 'client' }),
+        ],
+        [
+          'mock sid 2',
+          JSON.stringify({ to: 'bar to', recipientType: 'client' }),
+        ],
+        [
+          'mock sid 3',
+          JSON.stringify({ to: 'biff to', recipientType: 'number' }),
+        ],
+      ];
+      for (const [k, v] of mockAsyncStorage) {
+        asyncStorage.keyValueStore.set(k, v);
+      }
+    });
+
+    it('should read from async storage for an outgoing call', async () => {
+      const { type, payload } = await store.dispatch(bootstrapCalls());
+      expect(type).toMatch(/fulfilled/);
+      expect(payload).toBeUndefined();
+
+      expect(asyncStorage.getAllKeys.mock.calls).toStrictEqual([[]]);
+      expect(asyncStorage.getItem.mock.calls).toStrictEqual([['mock sid 1']]);
+
+      const { ids, entities } = store.getState().voice.call.activeCall;
+      const callEntity = entities[ids[0]];
+
+      if (callEntity?.status !== 'fulfilled') {
+        throw new Error('call entity not fulfilled');
+      }
+      if (callEntity?.direction !== 'outgoing') {
+        throw new Error('call direction should be outgoing');
+      }
+      expect(callEntity?.params).toStrictEqual({
+        to: 'foo to',
+        recipientType: 'client',
+      });
+    });
+
+    it('should clear values out of async storage if not active', async () => {
+      const { type, payload } = await store.dispatch(bootstrapCalls());
+      expect(type).toMatch(/fulfilled/);
+      expect(payload).toBeUndefined();
+
+      expect(asyncStorage.multiRemove.mock.calls).toStrictEqual([
+        [['mock sid 2', 'mock sid 3']],
+      ]);
+      expect(Array.from(asyncStorage.keyValueStore.entries())).toStrictEqual([
+        [
+          'mock sid 1',
+          JSON.stringify({
+            to: 'foo to',
+            recipientType: 'client',
+          }),
+        ],
       ]);
     });
   });

--- a/app/src/store/__tests__/voice/call/activeCall.test.ts
+++ b/app/src/store/__tests__/voice/call/activeCall.test.ts
@@ -6,6 +6,7 @@ import { makeOutgoingCall } from '../../../voice/call/outgoingCall';
 import { getAccessToken } from '../../../voice/accessToken';
 import { login } from '../../../user';
 import * as mockVoiceSdk from '../../../../../__mocks__/@twilio/voice-react-native-sdk';
+import * as asyncStorage from '../../../../../__mocks__/@react-native-async-storage/async-storage';
 
 jest.mock('../../../../util/fetch', () => ({
   fetch: jest.fn().mockResolvedValue({
@@ -21,6 +22,8 @@ describe('store', () => {
   const dispatchedActions: any[] = [];
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const logAction: Middleware = () => (next) => (action) => {
       dispatchedActions.push(action);
       next(action);
@@ -47,6 +50,7 @@ describe('store', () => {
     call = mockVoiceSdk.createMockCall.mock.results[0].value;
 
     dispatchedActions.splice(0);
+
     jest.clearAllMocks();
   });
 
@@ -371,6 +375,215 @@ describe('store', () => {
 
           matchDispatchedActions(dispatchedActions, [
             activeCall.setActiveCallInfo,
+          ]);
+        });
+      });
+
+      describe('handleCall', () => {
+        // TODO(mhuynh): [VBLOCKS-2078] Increase coverage.
+        it('reads from the async storage', async () => {
+          asyncStorage.keyValueStore.clear();
+          const mockAsyncStorage = [
+            [
+              'mock sid 1',
+              JSON.stringify({ to: 'foo to', recipientType: 'client' }),
+            ],
+            [
+              'mock sid 2',
+              JSON.stringify({ to: 'bar to', recipientType: 'client' }),
+            ],
+            [
+              'mock sid 3',
+              JSON.stringify({ to: 'biff to', recipientType: 'number' }),
+            ],
+          ];
+          for (const [k, v] of mockAsyncStorage) {
+            asyncStorage.keyValueStore.set(k, v);
+          }
+
+          const res = await store.dispatch(
+            activeCall.handleCall({
+              call: mockVoiceSdk.createMockCall('3') as any,
+            }),
+          );
+
+          if (activeCall.handleCall.rejected.match(res)) {
+            throw new Error('handle call should have fulfilled');
+          }
+          expect(res.payload.customParameters).toStrictEqual({
+            to: 'biff to',
+            recipientType: 'number',
+          });
+
+          const { entities, ids } = store.getState().voice.call.activeCall;
+          const callEntity = entities[ids[1]];
+
+          if (callEntity?.status !== 'fulfilled') {
+            throw new Error('call entity should be fulfilled');
+          }
+          if (callEntity?.direction !== 'outgoing') {
+            throw new Error('call entity should be outgoing');
+          }
+          expect(callEntity.params).toStrictEqual({
+            to: 'biff to',
+            recipientType: 'number',
+          });
+        });
+
+        it('handles when the async storage throws', async () => {
+          const err = new Error('get item error');
+          delete err.stack;
+          asyncStorage.getItem.mockRejectedValueOnce(err);
+
+          const res = await store.dispatch(
+            activeCall.handleCall({
+              call: mockVoiceSdk.createMockCall('3') as any,
+            }),
+          );
+
+          if (activeCall.handleCall.fulfilled.match(res)) {
+            throw new Error('handle call should have rejected');
+          }
+          expect(res.payload).toStrictEqual({
+            reason: 'ASYNC_STORAGE_GET_ITEM_REJECTED',
+            error: {
+              name: err.name,
+              message: err.message,
+            },
+          });
+        });
+
+        it('handles when the async storage holds invalid json', async () => {
+          asyncStorage.getItem.mockResolvedValueOnce('foobar');
+
+          const res = await store.dispatch(
+            activeCall.handleCall({
+              call: mockVoiceSdk.createMockCall('3') as any,
+            }),
+          );
+
+          if (activeCall.handleCall.fulfilled.match(res)) {
+            throw new Error('handle call should have rejected');
+          }
+          expect(res.payload?.reason).toStrictEqual('JSON_PARSE_THREW');
+          expect(res.payload?.error.name).toStrictEqual('SyntaxError');
+          expect(res.payload?.error.message).toStrictEqual(
+            'Unexpected token o in JSON at position 1',
+          );
+        });
+
+        it('handles when the async storage does not contain an entry', async () => {
+          asyncStorage.keyValueStore.clear();
+
+          const res = await store.dispatch(
+            activeCall.handleCall({
+              call: mockVoiceSdk.createMockCall('3') as any,
+            }),
+          );
+
+          if (activeCall.handleCall.rejected.match(res)) {
+            throw new Error('handle call should have fulfilled');
+          }
+          expect(res.payload.customParameters).toBeUndefined();
+
+          const { entities, ids } = store.getState().voice.call.activeCall;
+          const callEntity = entities[ids[1]];
+
+          if (callEntity?.status !== 'fulfilled') {
+            throw new Error('call entity should be fulfilled');
+          }
+          if (callEntity?.direction !== 'incoming') {
+            throw new Error('call entity should be incoming');
+          }
+        });
+
+        it('removes from the storage when the call is disconnected', async () => {
+          asyncStorage.keyValueStore.clear();
+          const mockAsyncStorage = [
+            [
+              'mock sid 1',
+              JSON.stringify({ to: 'foo to', recipientType: 'client' }),
+            ],
+            [
+              'mock sid 2',
+              JSON.stringify({ to: 'bar to', recipientType: 'client' }),
+            ],
+            [
+              'mock sid 3',
+              JSON.stringify({ to: 'biff to', recipientType: 'number' }),
+            ],
+          ];
+          for (const [k, v] of mockAsyncStorage) {
+            asyncStorage.keyValueStore.set(k, v);
+          }
+
+          const mockCall = mockVoiceSdk.createMockCall('3') as any;
+
+          await store.dispatch(
+            activeCall.handleCall({
+              call: mockCall,
+            }),
+          );
+
+          mockCall.emit('disconnected');
+
+          expect(
+            Array.from(asyncStorage.keyValueStore.entries()),
+          ).toStrictEqual([
+            [
+              'mock sid 1',
+              JSON.stringify({ to: 'foo to', recipientType: 'client' }),
+            ],
+            [
+              'mock sid 2',
+              JSON.stringify({ to: 'bar to', recipientType: 'client' }),
+            ],
+          ]);
+        });
+      });
+
+      describe('connectEvent', () => {
+        it('updates connect timestamp', () => {
+          store.dispatch(
+            activeCall.connectEvent({
+              id,
+              timestamp: 100,
+            }),
+          );
+
+          match(store.getState().voice.call.activeCall.entities[id])
+            .with({ initialConnectTimestamp: P.select() }, (t) =>
+              expect(t).toEqual(100),
+            )
+            .run();
+
+          matchDispatchedActions(dispatchedActions, [activeCall.connectEvent]);
+        });
+
+        it('ignores multiple', () => {
+          store.dispatch(
+            activeCall.connectEvent({
+              id,
+              timestamp: 100,
+            }),
+          );
+
+          store.dispatch(
+            activeCall.connectEvent({
+              id,
+              timestamp: 200,
+            }),
+          );
+
+          match(store.getState().voice.call.activeCall.entities[id])
+            .with({ initialConnectTimestamp: P.select() }, (t) =>
+              expect(t).toEqual(100),
+            )
+            .run();
+
+          matchDispatchedActions(dispatchedActions, [
+            activeCall.connectEvent,
+            activeCall.connectEvent,
           ]);
         });
       });

--- a/app/src/store/__tests__/voice/call/activeCall.test.ts
+++ b/app/src/store/__tests__/voice/call/activeCall.test.ts
@@ -541,52 +541,6 @@ describe('store', () => {
           ]);
         });
       });
-
-      describe('connectEvent', () => {
-        it('updates connect timestamp', () => {
-          store.dispatch(
-            activeCall.connectEvent({
-              id,
-              timestamp: 100,
-            }),
-          );
-
-          match(store.getState().voice.call.activeCall.entities[id])
-            .with({ initialConnectTimestamp: P.select() }, (t) =>
-              expect(t).toEqual(100),
-            )
-            .run();
-
-          matchDispatchedActions(dispatchedActions, [activeCall.connectEvent]);
-        });
-
-        it('ignores multiple', () => {
-          store.dispatch(
-            activeCall.connectEvent({
-              id,
-              timestamp: 100,
-            }),
-          );
-
-          store.dispatch(
-            activeCall.connectEvent({
-              id,
-              timestamp: 200,
-            }),
-          );
-
-          match(store.getState().voice.call.activeCall.entities[id])
-            .with({ initialConnectTimestamp: P.select() }, (t) =>
-              expect(t).toEqual(100),
-            )
-            .run();
-
-          matchDispatchedActions(dispatchedActions, [
-            activeCall.connectEvent,
-            activeCall.connectEvent,
-          ]);
-        });
-      });
     });
   });
 });

--- a/app/src/store/__tests__/voice/call/outgoingCall.test.ts
+++ b/app/src/store/__tests__/voice/call/outgoingCall.test.ts
@@ -183,6 +183,7 @@ describe('store', () => {
             .with({ payload: P.select() }, (p) => {
               expect(p).toStrictEqual({
                 from: 'mock from foo',
+                initialConnectedTimestamp: 42,
                 isMuted: false,
                 isOnHold: false,
                 sid: 'mock sid 1',
@@ -243,6 +244,7 @@ describe('store', () => {
             .with({ payload: P.select() }, (p) => {
               expect(p).toStrictEqual({
                 from: 'mock from foo',
+                initialConnectedTimestamp: 42,
                 isMuted: false,
                 isOnHold: false,
                 sid: 'mock sid 1',

--- a/app/src/store/__tests__/voice/call/outgoingCall.test.ts
+++ b/app/src/store/__tests__/voice/call/outgoingCall.test.ts
@@ -6,6 +6,7 @@ import { getAccessToken } from '../../../voice/accessToken';
 import { login } from '../../../user';
 import * as mockVoiceSdk from '../../../../../__mocks__/@twilio/voice-react-native-sdk';
 import * as voiceUtil from '../../../../util/voice';
+import * as asyncStorage from '../../../../../__mocks__/@react-native-async-storage/async-storage';
 
 jest.mock('../../../../util/fetch', () => ({
   fetch: jest.fn().mockResolvedValue({
@@ -147,6 +148,121 @@ describe('store', () => {
             makeOutgoingCall.pending,
             makeOutgoingCall.fulfilled,
           ]);
+        });
+
+        it('saves params to storage upon connected event', async () => {
+          asyncStorage.keyValueStore.clear();
+
+          const defer = deferNative(voiceUtil.voice, 'connect');
+
+          await store.dispatch(login());
+          await store.dispatch(getAccessToken());
+          dispatchedActions.splice(0);
+
+          const callPromise = store.dispatch(
+            makeOutgoingCall({
+              recipientType: 'number',
+              to: 'some random number foobar',
+            }),
+          );
+
+          match(
+            store.getState().voice.call.activeCall.entities[
+              callPromise.requestId
+            ],
+          )
+            .with({ status: 'pending' }, () => {})
+            .run();
+
+          const mockCall = mockVoiceSdk.createMockCall('foo');
+          mockCall.getSid.mockImplementation(() => 'mock sid 1');
+          defer.resolve(mockCall);
+
+          const callResult = await callPromise;
+          match(callResult)
+            .with({ payload: P.select() }, (p) => {
+              expect(p).toStrictEqual({
+                from: 'mock from foo',
+                isMuted: false,
+                isOnHold: false,
+                sid: 'mock sid 1',
+                state: 'mock state foo',
+                to: 'mock to foo',
+              });
+            })
+            .run();
+
+          matchDispatchedActions(dispatchedActions, [
+            makeOutgoingCall.pending,
+            makeOutgoingCall.fulfilled,
+          ]);
+
+          mockCall.emit('connected');
+
+          const entries = Array.from(
+            asyncStorage.keyValueStore.entries(),
+          ).reduce((reduction, [k, v]) => ({ ...reduction, [k]: v }), {});
+          expect(entries).toStrictEqual({
+            'mock sid 1': JSON.stringify({
+              to: 'some random number foobar',
+              recipientType: 'number',
+            }),
+          });
+        });
+
+        it('removes params from storage upon disconnect', async () => {
+          asyncStorage.keyValueStore.clear();
+
+          const defer = deferNative(voiceUtil.voice, 'connect');
+
+          await store.dispatch(login());
+          await store.dispatch(getAccessToken());
+          dispatchedActions.splice(0);
+
+          const callPromise = store.dispatch(
+            makeOutgoingCall({
+              recipientType: 'number',
+              to: 'some random number foobar',
+            }),
+          );
+
+          match(
+            store.getState().voice.call.activeCall.entities[
+              callPromise.requestId
+            ],
+          )
+            .with({ status: 'pending' }, () => {})
+            .run();
+
+          const mockCall = mockVoiceSdk.createMockCall('foo');
+          mockCall.getSid.mockImplementation(() => 'mock sid 1');
+          defer.resolve(mockCall);
+
+          const callResult = await callPromise;
+          match(callResult)
+            .with({ payload: P.select() }, (p) => {
+              expect(p).toStrictEqual({
+                from: 'mock from foo',
+                isMuted: false,
+                isOnHold: false,
+                sid: 'mock sid 1',
+                state: 'mock state foo',
+                to: 'mock to foo',
+              });
+            })
+            .run();
+
+          matchDispatchedActions(dispatchedActions, [
+            makeOutgoingCall.pending,
+            makeOutgoingCall.fulfilled,
+          ]);
+
+          mockCall.emit('disconnected');
+
+          const entries = Array.from(
+            asyncStorage.keyValueStore.entries(),
+          ).reduce((reduction, [k, v]) => ({ ...reduction, [k]: v }), {});
+          expect(entries).toStrictEqual({});
         });
       });
     });

--- a/app/src/store/bootstrap.ts
+++ b/app/src/store/bootstrap.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { miniSerializeError, type SerializedError } from '@reduxjs/toolkit';
 import {
   Voice,
@@ -209,9 +210,25 @@ export const bootstrapCalls = createTypedAsyncThunk<
     }
 
     const calls = callsResult.value;
+    // Get all the call sids stored in async storage.
+    const storedCallSids = new Set(await AsyncStorage.getAllKeys());
     for (const call of calls.values()) {
       await dispatch(handleCall({ call }));
+
+      // If the call is still active, the native layer will still have it
+      // cached.
+      const callSid = call.getSid();
+      if (callSid) {
+        // Mark a call as still active, and therefore keep it in async storage.
+        storedCallSids.delete(callSid);
+      }
     }
+
+    /**
+     * Free the AsyncStorage if there are some calls in AsyncStorage that are
+     * no longer tracked by the native layer.
+     */
+    await AsyncStorage.multiRemove(Array.from(storedCallSids.values()));
   },
 );
 

--- a/app/src/store/voice/call/index.ts
+++ b/app/src/store/voice/call/index.ts
@@ -93,8 +93,12 @@ export type IncomingCall = {
   direction: 'incoming';
 } & BaseCall;
 
-export type OutgoingCall = {
-  direction: 'outgoing';
+export type OutgoingCallParameters = {
   recipientType: RecipientType;
   to: string;
+};
+
+export type OutgoingCall = {
+  direction: 'outgoing';
+  params: OutgoingCallParameters;
 } & BaseCall;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1227,6 +1227,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@react-native-async-storage/async-storage@^1.19.2":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.19.2.tgz#44f0af5927a04436b3f67aae67f028b888ff452c"
+  integrity sha512-7jTQKbT3BdhFHQMnfElsLeeyVqNICv72lPKbeNHnNgLP9eH3+Yk1GFMWWb7A8qRMYianSmwmx1cYofNe9H9hLQ==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/cli-clean@^9.2.1":
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-9.2.1.tgz#198c5dd39c432efb5374582073065ff75d67d018"
@@ -5106,6 +5113,13 @@ memoize-one@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Submission Checklist

 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] New unit tests and integration tests have beed added
 - [x] Code coverage is more or equal to the previous coverage
 - [x] A visual inspection of the `Files changed` tab was made prior to submitting the pull request ensuring the style guide was followed
 - [x] [CI pipeline](https://app.circleci.com/pipelines/github/twilio/twilio-voice-react-native-app) is green
 - [ ] Included screenshot if necessary

## Description

This PR persists the outgoing call parameters for UX purposes.

### Breakdown

- Use AsyncStorage library to persist information about outgoing calls between JS runtimes.
- Slight refactor of the custom parameters info submember of the call entity type.

## Validation

- Unit tests.
- Manual testing on Android.

## Additional Notes

N/A

## Contributing to Twilio

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
