### PR TITLE
[VBLOCKS-2363] fix: ios timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 explicit and has finer control.
 * Upgraded Twilio Voice SDK to `1.0.0-rc8`.
 
+### Fixes
+* Call timer for iOS, no longer shows negative numbers
+
 # 1.0.0-beta.1 (Aug 23, 2023)
 
 ## App

--- a/app/src/store/voice/call/index.ts
+++ b/app/src/store/voice/call/index.ts
@@ -30,7 +30,6 @@ export const getCallInfo = (call: TwilioCall): CallInfo => {
     Platform.OS,
   ])
     .with([undefined, P._], () => undefined)
-    .with([P.not(undefined), 'ios'], ([timestamp]) => Number(timestamp) * 1000)
     .with([P.not(undefined), P._], ([timestamp]) => Number(timestamp))
     .exhaustive();
 

--- a/app/src/store/voice/call/index.ts
+++ b/app/src/store/voice/call/index.ts
@@ -24,9 +24,9 @@ export const getCallInfo = (call: TwilioCall): CallInfo => {
   const to = call.getTo();
   const from = call.getFrom();
 
-  const initialConnectedTimestamp = match([call.getInitialConnectedTimestamp()])
-    .with([undefined], () => undefined)
-    .with([P.not(undefined)], ([timestamp]) => Number(timestamp))
+  const initialConnectedTimestamp = match(call.getInitialConnectedTimestamp())
+    .with(undefined, () => undefined)
+    .with(P._, (timestamp) => Number(timestamp))
     .exhaustive();
 
   const isMuted = Boolean(call.isMuted());

--- a/app/src/store/voice/call/index.ts
+++ b/app/src/store/voice/call/index.ts
@@ -3,7 +3,6 @@ import {
   type CallInvite as TwilioCallInvite,
   type CustomParameters,
 } from '@twilio/voice-react-native-sdk';
-import { Platform } from 'react-native';
 import { match, P } from 'ts-pattern';
 import { type AsyncStoreSlice } from '../../app';
 
@@ -25,12 +24,9 @@ export const getCallInfo = (call: TwilioCall): CallInfo => {
   const to = call.getTo();
   const from = call.getFrom();
 
-  const initialConnectedTimestamp = match([
-    call.getInitialConnectedTimestamp(),
-    Platform.OS,
-  ])
-    .with([undefined, P._], () => undefined)
-    .with([P.not(undefined), P._], ([timestamp]) => Number(timestamp))
+  const initialConnectedTimestamp = match([call.getInitialConnectedTimestamp()])
+    .with([undefined], () => undefined)
+    .with([P.not(undefined)], ([timestamp]) => Number(timestamp))
     .exhaustive();
 
   const isMuted = Boolean(call.isMuted());


### PR DESCRIPTION
## Submission Checklist

 - [x] The `README.md` reflects new **features**
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] New unit tests and integration tests have beed added
 - [x] Code coverage is more or equal to the previous coverage
 - [x] A visual inspection of the `Files changed` tab was made prior to submitting the pull request ensuring the style guide was followed
 - [ ] [CI pipeline](https://app.circleci.com/pipelines/github/twilio/twilio-voice-react-native-app) is green
 - [ ] Included screenshot if necessary

## Description

[VBLOCKS-2363](https://issues.corp.twilio.com/browse/VBLOCKS-2363)

iOS timer showing negative numbers. Due to iOS time being multiplied by 1000

### Breakdown

- removed the x1000 multiplier

## Validation

- local testing

## Additional Notes

![IMG_5336](https://github.com/twilio/twilio-voice-react-native-app/assets/35968892/fb394ed6-30c4-4c7e-aecf-1d86b02ea314)



## Contributing to Twilio

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
