### PR TITLE
[VLBOCKS-2362] fix: center splash screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ explicit and has finer control.
 * Upgraded Twilio Voice SDK to `1.0.0-rc8`.
 
 ### Fixes
-* Call timer for iOS, no longer shows negative numbers
+* iOS call timer, no longer shows negative numbers
+* iOS splash screen centered for larger screens
 
 # 1.0.0-beta.1 (Aug 23, 2023)
 

--- a/app/ios/TwilioVoiceReactNativeReferenceApp/LaunchScreen.storyboard
+++ b/app/ios/TwilioVoiceReactNativeReferenceApp/LaunchScreen.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,8 +20,8 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="launch_image" id="LDp-yv-eZv">
-                                <rect key="frame" x="-164" y="1" width="700" height="812"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="-165" y="0.0" width="700" height="812"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" red="0.022723957900000001" green="0.01154816616" blue="0.21570128199999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>


### PR DESCRIPTION
## Submission Checklist

 - [x] The `README.md` reflects new **features**
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] New unit tests and integration tests have beed added
 - [x] Code coverage is more or equal to the previous coverage
 - [x] A visual inspection of the `Files changed` tab was made prior to submitting the pull request ensuring the style guide was followed
 - [ ] [CI pipeline](https://app.circleci.com/pipelines/github/twilio/twilio-voice-react-native-app) is green
 - [x] Included screenshot if necessary

## Description

[VLBOCKS-2362](https://issues.corp.twilio.com/browse/VBLOCKS-2362)

### Breakdown

- Fixed autoresizing of splash screen

## Validation

- manual testing

## Additional Notes

<img width="530" alt="Screenshot 2023-12-07 at 3 33 27 PM" src="https://github.com/twilio/twilio-voice-react-native-app/assets/35968892/1a45de1b-e1ff-486c-8e5d-1803500f31e4">

## Contributing to Twilio

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
