### PR TITLE
feat: add option to disable flipper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ explicit and has finer control.
   ```
   pod install
   ```
+  See [docs/known-issues.md](./docs/known-issues.md) for more information.
 
 ### Fixes
 * iOS call timer, no longer shows negative numbers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 explicit and has finer control.
 * Upgraded Twilio Voice SDK to `1.0.0-beta.4`.
 * Refactored Android implementation to use newly refactored Android Voice React Native SDK
+* Flipper is causing some build issues on Xcode version 15.3.
+  An option to disable Flipper during `pod install` has been added to the Podfile of this project.
+  To disable Flipper:
+  ```
+  NO_FLIPPER=1 pod install
+  ```
+  To continue using Flipper as normal, no changes are necessary to your workflow:
+  ```
+  pod install
+  ```
 
 ### Fixes
 * iOS call timer, no longer shows negative numbers

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Please see the `README.md` files within each sub-folder for more information abo
 
 See [docs/e2e-testing.md](./docs/e2e-testing.md) if you plan to e2e test your fork of this app.
 
+## Known Issues
+
+See [docs/known-issues.md](./docs/known-issues.md) for details on known issues and workarounds.
+
 ## Related
 
 * [Twilio Voice React Native](https://github.com/twilio/twilio-voice-react-native)

--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -21,7 +21,7 @@ target 'TwilioVoiceReactNativeReferenceApp' do
     #
     # Note that if you have use_frameworks! enabled, Flipper will not work and
     # you should disable the next line.
-    :flipper_configuration => FlipperConfiguration.enabled,
+    :flipper_configuration => ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled,
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,14 @@
+# Known Issues
+This document lists known issues and workarounds.
+
+## iOS Build Issues regarding Flipper
+Flipper has an upstream issue that prevents builds from completing on Xcode
+version 15.3.
+
+If you are not using Flipper in your workflow, you can disable Flipper during
+the `pod install` step by passing an environment variable `NO_FLIPPER` with a
+value of `1`.
+
+```sh
+NO_FLIPPER=1 pod install
+```


### PR DESCRIPTION
## Submission Checklist

 - [x] The `README.md` reflects new **features**
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] New unit tests and integration tests have beed added
 - [x] Code coverage is more or equal to the previous coverage
 - [x] A visual inspection of the `Files changed` tab was made prior to submitting the pull request ensuring the style guide was followed
 - [x] [CI pipeline](https://app.circleci.com/pipelines/github/twilio/twilio-voice-react-native-app) is green
 - [x] Included screenshot if necessary

## Description

This PR adds an option during `pod install` such that you can disable Flipper. It can be used like so
```
NO_FLIPPER=1 pod install # this will disable flipper
```
If you want to use Flipper you can `pod install` as normal
```
pod install
```

### Breakdown

- Add env var check to the podfile. This change was taken from newer versions of react native podfiles.

## Validation

- Ran pod install with and without the flag, Flipper was pulled or not pulled accordingly.

## Additional Notes

N/A

## Contributing to Twilio

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
