### PR TITLE
[VBLOCKS-2877] Prepare repo for GA release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ aliases:
   - &android-executor
     name: android/android-machine
     resource-class: large
-    tag: 2023.07.1
+    tag: 2024.01.1
 
   - &app-package-json-key
     app-dependencies-{{ arch }}-{{ checksum "app/package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ aliases:
   - &android-executor
     name: android/android-machine
     resource-class: large
-    tag: 2024.01.1
+    tag: 2023.07.1
 
   - &app-package-json-key
     app-dependencies-{{ arch }}-{{ checksum "app/package.json" }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 1.0.0-beta.2 (In Progress)
+# 1.0.0 (Mar 25, 2024)
+
+The Twilio Voice React Native Reference App has reached milestone `1.0.0` and is
+considered Generally Available (GA). Included in this release are the following.
 
 ## App
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ considered Generally Available (GA). Included in this release are the following.
 ### Changes
 * Refactored and simplified navigators. Now, movement between screens is more
 explicit and has finer control.
-* Upgraded Twilio Voice SDK to `1.0.0-rc23`.
+* Upgraded Twilio Voice SDK to `1.0.0`.
 * Refactored Android implementation to use newly refactored Android Voice React Native SDK
 * Flipper is causing some build issues on Xcode version 15.3.
   An option to disable Flipper during `pod install` has been added to the Podfile of this project.

--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,7 @@
     "@react-navigation/native": "^6.1.2",
     "@react-navigation/native-stack": "^6.9.8",
     "@reduxjs/toolkit": "^1.9.1",
-    "@twilio/voice-react-native-sdk": "https://github.com/twilio/twilio-voice-react-native/archive/refs/tags/1.0.0-rc24.tar.gz",
+    "@twilio/voice-react-native-sdk": "1.0.0",
     "react": "18.1.0",
     "react-native": "0.70.9",
     "react-native-auth0": "^3.0.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1559,9 +1559,10 @@
   resolved "https://registry.yarnpkg.com/@twilio/voice-errors/-/voice-errors-1.4.0.tgz#0ab954085a32a00442814e56c95936908871ff6e"
   integrity sha512-7BCg9MPz+KQ0JJ6Rl5W3Zw3E+i3Tt77VZw3/2i3Z+IPZITmCOQLu1nKx/0Nlj505Xtfr7eY9Mcern5PfIoBW0w==
 
-"@twilio/voice-react-native-sdk@https://github.com/twilio/twilio-voice-react-native/archive/refs/tags/1.0.0-rc24.tar.gz":
-  version "1.0.0-rc24"
-  resolved "https://github.com/twilio/twilio-voice-react-native/archive/refs/tags/1.0.0-rc24.tar.gz#aa52147e64c6d51de418eed8f49ee526051bea5b"
+"@twilio/voice-react-native-sdk@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@twilio/voice-react-native-sdk/-/voice-react-native-sdk-1.0.0.tgz#afb995e2f26ac414f9497a7c4c7a77ddccc65d2e"
+  integrity sha512-t2hB+4GMJvi6d+6UVUsPVY60lv8rNamJJ3C41ibYKDRIdGsQgeFvGsMPUrm5RlOU4420iSWecCO4wVdJPylVSg==
   dependencies:
     "@twilio/voice-errors" "^1.2.2"
     eventemitter3 "^4.0.7"


### PR DESCRIPTION
## Submission Checklist

 - [x] The `README.md` reflects new **features**
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] New unit tests and integration tests have beed added
 - [x] Code coverage is more or equal to the previous coverage
 - [x] A visual inspection of the `Files changed` tab was made prior to submitting the pull request ensuring the style guide was followed
 - [x] [CI pipeline](https://app.circleci.com/pipelines/github/twilio/twilio-voice-react-native-app) is green
 - [x] Included screenshot if necessary

## Description

This PR prepares the repo for GA release by removing Beta tags where applicable and updating changelogs.

### Breakdown

- Update changelog to version `1.0.0`.
- Update Voice SDK dependency to `1.0.0`.

## Validation

- Manually tested and built the app with `1.0.0`.

```md
[x] android
  [x] outgoing call
    [x] accept
      [x] disconnect by remote
      [x] disconnect by local
    [x] reject
    [x] cancel
  [x] incoming call
    [x] tap on notification
      [x] js accept
        [x] disconnect by remote
        [x] disconnect by local
      [x] js reject
      [x] cancel
    [x] native accept
      [x] disconnect by remote
      [x] disconnect by local
    [x] native reject
    [x] cancel

[x] ios
  [x] outgoing call
    [x] accept
      [x] disconnect by remote
      [x] disconnect by local
    [x] reject
    [x] cancel
  [x] incoming call
    [x] tap on notification
      [x] callkit accept
        [x] disconnect by remote
        [x] disconnect by local
      [x] callkit reject
      [x] cancel
    [x] do not tap on notification
      [x] native accept
        [x] disconnect by remote
        [x] disconnect by local
      [x] native reject
      [x] cancel
```

## Additional Notes

N/A

## Contributing to Twilio

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
