### PR TITLE
fix: set sdk version to 34

### DIFF
--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "31.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 33
-        targetSdkVersion = 33
+        compileSdkVersion = 34
+        targetSdkVersion = 34
         kotlinVersion = "1.8.0"
         // use the same NDK version as the Voice SDK
         ndkVersion = "25.2.9519653"


### PR DESCRIPTION
## Submission Checklist

 - [x] The `README.md` reflects new **features**
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] ~New unit tests and integration tests have beed added~
 - [x] Code coverage is more or equal to the previous coverage
 - [x] A visual inspection of the `Files changed` tab was made prior to submitting the pull request ensuring the style guide was followed
 - [ ] [CI pipeline](https://app.circleci.com/pipelines/github/twilio/twilio-voice-react-native-app) is green
 - [x] ~Included screenshot if necessary~

## Description

This PR sets the Android SDK version to 34 to facilitate easier Play Store publishing.

### Breakdown

- Set SDK versions to 34.

## Validation

- CI builds and passes.
- Local environment builds and passes basic testing.

## Additional Notes

N/A

## Contributing to Twilio

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
